### PR TITLE
Setting this.upgrade to false in the constructor, so that isClosed does not always return false

### DIFF
--- a/lib/rest-handler/REST.js
+++ b/lib/rest-handler/REST.js
@@ -40,6 +40,7 @@ Accept.prototype.getMimeType = function() {
 
 function REST(handler, domain) {
     this.handler = handler;
+    this.upgrade = false;
 }
 
 REST.prototype = {


### PR DESCRIPTION
Phil,

I just discovered this issue tonight.I have my custom serialization handler, however, the default handler was always invoked. After some digging I found that was due to REST.isClosed() returning false because REST.upgrade is undefined.

Thanks,
--aydan
