### PR TITLE
Add support for 405: Method Not Allowed

### DIFF
--- a/lib/rest-handler/RESTHandler.js
+++ b/lib/rest-handler/RESTHandler.js
@@ -11,6 +11,7 @@ function RESTHandler(options) {
 	events.EventEmitter.call(this);
 	this._routerByMethod = {};
     this.ALL_ROUTES_METHOD = "AllRoutes";
+    this.routes = {};
 
 	// array of functions that will be invoked prior to request being dispatched to final route function
 	this._before = [];
@@ -29,9 +30,27 @@ function RESTHandler(options) {
 
 util.inherits(RESTHandler, events.EventEmitter);
 
+RESTHandler.prototype._registerRoute = function(method, route) {
+    if (this.routes.hasOwnProperty(route)) {
+        this.routes[route].methods.push(method);
+    } else {
+        this.routes[route] = {
+            methods:[method]
+        };
+    }
+};
+
+RESTHandler.prototype._getMethodsForRoute = function(route) {
+    if (this.routes.hasOwnProperty(route)) {
+        return this.routes[route].methods;
+    }
+    return null;
+};
+
 RESTHandler.prototype._addRoute = function(method, routeConfig) {
 	var route = this.getMethodRouter(method).addRoute(routeConfig);
     this.getMethodRouter(this.ALL_ROUTES_METHOD).addRoute(routeConfig);
+    this._registerRoute(method, route);
 	route.restHandler = this;
 
 	// notify listeners that route was added
@@ -73,9 +92,10 @@ RESTHandler.prototype._rest = function(req, res, socket, domain) {
 
 	if (!match) {
         // Check if the route exists regardless of method
-        if (this._findRoute(this.ALL_ROUTES_METHOD, reqUrl)) {
+        var route = this._findRoute(this.ALL_ROUTES_METHOD, reqUrl);
+        if (route) {
             this.emit('methodNotAllowed', req, res, socket);
-            this.methodNotAllowed('Method Not Allowed', req, res, socket);
+            this.methodNotAllowed('Method Not Allowed', req, res, socket, this._getMethodsForRoute(route.route));
         } else {
             this.emit('routeNotFound', req, res, socket);
             this.notFound('Not found', req, res, socket);
@@ -145,7 +165,7 @@ RESTHandler.prototype.notFound = function(message, req, res, socket) {
 	}
 };
 
-RESTHandler.prototype.methodNotAllowed = function(message, req, res, socket) {
+RESTHandler.prototype.methodNotAllowed = function(message, req, res, socket, methods) {
 
     if (arguments.length === 2) {
         req = arguments[0];
@@ -155,6 +175,7 @@ RESTHandler.prototype.methodNotAllowed = function(message, req, res, socket) {
 
     if (res) {
         res.setHeader('Content-Type', 'text/plain');
+        res.setHeader('Allow', methods.join());
         res.statusCode = 405;
         res.end(message);
     } else if (socket) {


### PR DESCRIPTION
This seems like a pretty naive approach, but I couldn't think of a better way to leverage the amd-router's request URI to "route" matching algorithm. I'm open to suggestions!
