### PR TITLE
Add ability to provide a custom  handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,26 @@ restHandler.errorHandler(function(rest, err) {
 });
 ```
 
+**Override notFound handler:**
+```javascript
+// By default the notFound handler will send the status message as plaintext with a 404 status code.
+// You can override this behavior using the `onRouteNotFound` option.
+require('rest-handler').create({
+    onRouteNotFound: function (message, req, res, socket) {
+        if (typeof message !== "string") {
+            // Message is optional.
+            res = req;
+            req = message;
+        }
+
+        // Respond however you would like.
+        res.statusCode = 200;
+        res.end("Hello World");
+    }
+})
+```
+
+
 **Start an http server and delegate handling of requests to REST handler:**
 ```javascript
 // Create standard HTTP server

--- a/lib/rest-handler/RESTHandler.js
+++ b/lib/rest-handler/RESTHandler.js
@@ -17,6 +17,8 @@ function RESTHandler(options) {
 	this._before = [];
 
 	if (options) {
+		this._onRouteNotFound = options.onRouteNotFound;
+
 		if (options.routes) {
 			for (var i = 0; i < options.routes.length; i++) {
 				this.addRoute(options.routes[i]);
@@ -197,6 +199,10 @@ RESTHandler.prototype.handleUpgrade = function(req, socket, head, domain) {
 };
 
 RESTHandler.prototype.notFound = function(message, req, res, socket) {
+	if (this._onRouteNotFound) {
+		this._onRouteNotFound(message. req, res, socket);
+		return;
+	}
 
 	if (arguments.length === 2) {
 		req = arguments[0];

--- a/test/rest-handler-test.js
+++ b/test/rest-handler-test.js
@@ -319,3 +319,31 @@ describe('route request', function() {
         });
     });
 });
+
+describe('notFound overrride', function() {
+    var myRestHandler = require('..')
+        .create({
+            onRouteNotFound: function(message, req, res, socket) {
+                if (typeof message !== "string") {
+                    res = req;
+                    req = message;
+                }
+
+                res.setHeader('Content-Type', 'text/plain');
+                res.statusCode = 200;
+                res.end("Custom Handler");
+            }
+        });
+
+    it('should send 200 for unrecognized route', function() {
+        var req = new MockRequest();
+        req.url = '/does/not/exist';
+
+        var res = new MockResponse();
+
+        myRestHandler.handle(req, res);
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.mock_getWritten()).to.equal("Custom Handler");
+    });
+});


### PR DESCRIPTION
Currently as far as I can tell there is no way to opt out of the default functionality of handling 404s.

Having the ability to override this is particularly handy for stuff like proxying to a different router when a match is not found among other things.

Let me know if you have any feedback on the API or PR in general.